### PR TITLE
Relative col widths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.cache/
+/.coverage
+/.tox/
+/MANIFEST
+/__pycache__/
+*.egg-info/
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ if sys.version < '2.2.3':
 
 setup(
     name = "texttable",
-    version = "0.8.7",
-    author = "Gerome Fournier", 
+    version = "0.8.8",
+    author = "Gerome Fournier",
     author_email = "jef(at)foutaise.org",
     url = "https://github.com/foutaise/texttable/",
     download_url = "https://github.com/foutaise/texttable/archive/v0.8.7.tar.gz",
@@ -55,5 +55,11 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing',
         'Topic :: Utilities',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ]
 )

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,122 @@
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import re
+from textwrap import dedent
+
+from texttable import Texttable
+
+def clean(text):
+    return re.sub(r'( +)$', '', text, flags=re.MULTILINE) + '\n'
+
+
+def test_texttable():
+    table = Texttable()
+    table.set_cols_align(["l", "r", "c"])
+    table.set_cols_valign(["t", "m", "b"])
+    table.add_rows([
+        ["Name", "Age", "Nickname"],
+        ["Mr\nXavier\nHuon", 32, "Xav'"],
+        ["Mr\nBaptiste\nClement", 1, "Baby"],
+        ["Mme\nLouise\nBourgeau", 28, "Lou\n \nLoue"],
+    ])
+    assert clean(table.draw()) == dedent('''\
+        +----------+-----+----------+
+        |   Name   | Age | Nickname |
+        +==========+=====+==========+
+        | Mr       |     |          |
+        | Xavier   |  32 |          |
+        | Huon     |     |   Xav'   |
+        +----------+-----+----------+
+        | Mr       |     |          |
+        | Baptiste |   1 |          |
+        | Clement  |     |   Baby   |
+        +----------+-----+----------+
+        | Mme      |     |   Lou    |
+        | Louise   |  28 |          |
+        | Bourgeau |     |   Loue   |
+        +----------+-----+----------+
+    ''')
+
+
+def test_texttable_header():
+    table = Texttable()
+    table.set_deco(Texttable.HEADER)
+    table.set_cols_dtype([
+        't',  # text
+        'f',  # float (decimal)
+        'e',  # float (exponent)
+        'i',  # integer
+        'a',  # automatic
+    ])
+    table.set_cols_align(["l", "r", "r", "r", "l"])
+    table.add_rows([
+        ["text",    "float", "exp", "int", "auto"],
+        ["abcd",    "67",    654,   89,    128.001],
+        ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
+        ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
+        ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000],
+    ])
+    assert clean(table.draw()) == dedent('''\
+         text     float       exp      int     auto
+        ==============================================
+        abcd      67.000   6.540e+02    89   128.001
+        efghijk   67.543   6.540e-01    90   1.280e+22
+        lmn        0.000   5.000e-78    89   0.000
+        opqrstu    0.023   5.000e+78    92   1.280e+22
+    ''')
+
+
+def test_set_cols_width():
+    table = Texttable()
+    table.set_deco(Texttable.HEADER)
+    table.set_cols_width([10, 10])
+    table.add_rows([
+        ["key", "value"],
+        [1,     "a"],
+        [2,     "b"],
+    ])
+    assert clean(table.draw()) == dedent('''\
+           key         value
+        =======================
+        1            a
+        2            b
+    ''')
+
+
+def test_exceeding_max_width():
+    table = Texttable(max_width=40)
+    table.set_deco(Texttable.HEADER)
+    table.add_rows([
+        ["key", "value"],
+        [1,     "a"],
+        [2,     "b"],
+        [3,     "very long, very long, very long"],
+    ])
+    assert clean(table.draw()) == dedent('''\
+        key               value
+        ====================================
+        1     a
+        2     b
+        3     very long, very long, very
+              long
+    ''')
+
+
+def test_obj2unicode():
+    table = Texttable()
+    table.set_deco(Texttable.HEADER)
+    table.add_rows([
+        ["key", "value"],
+        [1,     "a"],
+        [2,     1],
+        [3,     None],
+    ])
+    assert clean(table.draw()) == dedent('''\
+        key   value
+        ===========
+        1     a
+        2     1
+        3     None
+    ''')

--- a/texttable.py
+++ b/texttable.py
@@ -70,6 +70,10 @@ Result:
     mnop   0.023    5.000e+78   92    1.280e+22
 """
 
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 __all__ = ["Texttable", "ArraySizeError"]
 
 __author__ = 'Gerome Fournier <jef(at)foutaise.org>'
@@ -133,12 +137,14 @@ def obj2unicode(obj):
     """
     if isinstance(obj, unicode_type):
         return obj
-    else:
+    elif isinstance(obj, bytes_type):
         try:
-            return unicode_type(obj, 'utf')
+            return unicode_type(obj, 'utf-8')
         except UnicodeDecodeError as strerror:
             sys.stderr.write("UnicodeDecodeError exception for string '%s': %s\n" % (obj, strerror))
-            return unicode_type(obj, 'utf', 'replace')
+            return unicode_type(obj, 'utf-8', 'replace')
+    else:
+        return unicode_type(obj)
 
 
 def len(iterable):
@@ -524,10 +530,12 @@ class Texttable:
                 except (TypeError, IndexError):
                     maxi.append(self._len_cell(cell))
         items = len(maxi)
-        length = reduce(lambda x, y: x+y, maxi)
+        length = sum(maxi)
         if self._max_width and length + items * 3 + 1 > self._max_width:
-            maxi = [(self._max_width - items * 3 -1) // items \
-                    for n in range(items)]
+            maxi = [
+                int(round(self._max_width / (length + items * 3 + 1) * n))
+                for n in maxi
+            ]
         self._width = maxi
 
     def _check_align(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py35,py36
+
+[testenv]
+deps =
+    pytest
+    pytest-cov
+commands = py.test --cov-report=term-missing --cov=texttable tests.py


### PR DESCRIPTION
Previously texttable was drawing tables that do not fit into specified width
like this:

```
      key               value
===================================
1                  a
2                  b
3                  very long, very
                   long, very long
```

As you can see, all columns has same widths.

After this fix, table drawn like this:

```
key               value
====================================
1     a
2     b
3     very long, very long, very
      long
```

Here space is used much more efficiently than before.

In addition, to not break things, added tests for Python 2.7, 3.5 and 3.6. There is only few tests, but test coverage is 84%.