### PR TITLE
fix: width of table exceeds max_width parameter

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -87,15 +87,15 @@ def test_exceeding_max_width():
         ["key", "value"],
         [1,     "a"],
         [2,     "b"],
-        [3,     "very long, very long, very long"],
+        [3,     "very long, very long, very long, very long"],
     ])
     assert clean(table.draw()) == dedent('''\
-        key               value
-        ====================================
+        key                 value
+        =======================================
         1     a
         2     b
-        3     very long, very long, very
-              long
+        3     very long, very long, very long,
+              very long
     ''')
 
 


### PR DESCRIPTION
## Problem
### The width of table exceeds max_width parameter.
for example:
```
table = Texttable(max_width=9)
table.add_rows([
    ["a", "b"],
    [1, "+"],
    [2, "++"],
])
print(table.draw())
```

width of the output table is 10
```
+---+----+
| a | b  |
+===+====+
| 1 | +  |
+---+----+
| 2 | ++ |
+---+----+
```


another example:
```
table = Texttable(max_width=10)
table.set_deco(Texttable.HEADER)
table.add_rows([
    ["a", "b"],
    [1, "+"],
    [22, "++++"],
])
print(table.draw())
```

width of the output table is 9, but the second column wraps when it should not
```
a     b  
========
1    +   
22   +++ 
     + 
```

## Solve the problem
have a look at the code in line 534
```
maxi = [ int(round(self._max_width / (length + items * 3 + 1) * n)) for n in maxi ]
```
length is the sum of all columns content
items is the number of columns
it **allocates space by proportion of each column**

There are 2 mistakes. I noticed that it was introduced by #13 

### handle the extra space
what does `items * 3 + 1` mean? it is the extra space surrouding column content.

every column is followed by a space
there are always 2 chars between 2 colums. if the table has vline it's a char_vert plus a space otherwise 2 spaces
if the table has border it will take 3 more space in two sides.

so the exact extra space is:
```
extra = items + (items -1) * 2 + [0, 3][self._has_border()]
```

in addition it doesn't make sense to count the extra space into the `length` which is going to be squeezed. Instead the extra space should be subtracted from the total available space `self._max_width`.

the correcte code should be:
```
if self._max_width and length > self._max_width - extra:
    maxi = [
        int(round((self._max_width - extra) / length * n))
        for n in maxi
    ]
```


### round is not good
The problem is not finished yet.
an example:
```
table = Texttable(max_width=10)
table.add_rows([
    ["a", "b"],
    [1, "+"],
    [22, "++"],
])
print(table.draw())
```

width of the output table is 11
```
+----+----+
| a  | b  |
+====+====+
| 1  | +  |
+----+----+
| 22 | ++ |
+----+----+
```
why?
Since the available space for column content is
```
10-(3*3-2) = 3
```
allocate 3 to two columns which need 4.
```
round(3/4 * 2)=2
round(3/4 * 2)=2
```
so **the allocated space exceeds available space**

we need a new allocate method:
```
def allocate_space(n, l):
    """allocate n to len(l) numbers according to their protion in l
    """
    s = sum(l)
    floor = {}
    result = []
    for i, v in enumerate(l):
      q, r = divmod(n*v, s)
      result.append(q)
      # keep those who can share remaining space
      if r:
          floor[i]=v
    s = sum(result)
    assert (n-s)<=len(floor)
    # sort by value and save their indexes
    floor = [i for i, _ in sorted(floor.items(), key=lambda x: x[1])]
    # allocate the remaining space from the smallest
    for i in range(n-s):
        result[floor[i]] += 1
    return result
```
I make it a inner function in `_compute_cols_width`.
I am happy to accept any good advice about the code style.

It may look redundant but it will make sure available space is allocated correctly.


## Improvment
Maybe it's not the best method to be divided in portion.
For example, too long column may consume too much space
```
table = Texttable(max_width=12)
table.add_rows([
    ["a", "b"],
    [1, "+"],
    [22, "++++++++"],
])
print(table.draw())
```
the first column wraps too 
```
+---+------+
| a |  b   |
+===+======+
| 1 | +    |
+---+------+
| 2 | ++++ |
| 2 | ++++ |
+---+------+
```

Here I propose a more appropriate method to allocate space to columns in a table when it exceeds the maximum width.
**Colums under the mean width can obtain what they need. Other columns share the mean of the left width.**
```
def allocate_space(n, l):
    """allocate n to len(l) numbers
    """
    s = sum(l)
    assert s>n
    size = len(l)
    result = [0] * size
    i = 0
    while n > 0:
        if result[i] < l[i]:
            result[i] += 1
            n -= 1
        i = (i+1) % size
    return result
```

It can not only protect from the too long columns but also keep the number of columns which should be wrapped as few as possible.

This new compute method is **not included in this pull request** because it needs more practice before it proved to be an improvement compared to the current method. I keep it in another branch of my repository.

