### PR TITLE
remove the trailing space if there is no border

### DIFF
--- a/texttable.py
+++ b/texttable.py
@@ -577,15 +577,15 @@ class Texttable:
                 if isheader:
                     align = "c"
                 if align == "r":
-                    out += "%s " % (fill * space + cell_line)
+                    out += "%s" % (fill * space + cell_line)
                 elif align == "c":
-                    out += "%s " % (int(fill/2) * space + cell_line \
+                    out += "%s" % (int(fill/2) * space + cell_line \
                             + int(fill/2 + fill%2) * space)
                 else:
-                    out += "%s " % (cell_line + fill * space)
+                    out += "%s" % (cell_line + fill * space)
                 if length < len(line):
-                    out += "%s " % [space, self._char_vert][self._has_vlines()]
-            out += "%s\n" % ['', self._char_vert][self._has_border()]
+                    out += " %s " % [space, self._char_vert][self._has_vlines()]
+            out += "%s\n" % ['', space + self._char_vert][self._has_border()]
         return out
 
     def _splitit(self, line, isheader):


### PR DESCRIPTION
I am very happy to see your change in [fe64d4c](https://github.com/foutaise/texttable/pull/15#issuecomment-292711289)
Please let me add that the use of space should be modified as you mention in #15 
> columns are always separated by 3 spaces, even if no vertical delimiter is specified (a space is used instead).
> Add to this 2 spaces at the beginning/end of the row if the table has a border

Thx!