### PR TITLE
add support for combining characters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,13 +33,14 @@ if sys.version < '2.2.3':
 
 setup(
     name = "texttable",
-    version = "0.9.0",
+    version = "0.9.1",
     author = "Gerome Fournier",
     author_email = "jef(at)foutaise.org",
     url = "https://github.com/foutaise/texttable/",
     download_url = "https://github.com/foutaise/texttable/archive/v0.9.0.tar.gz",
     license = "LGPL",
     py_modules = ["texttable"],
+    install_requires = ["wcwidth"],
     description = DESCRIPTION,
     long_description = LONG_DESCRIPTION,
     platforms = "any",

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from textwrap import dedent
 from texttable import Texttable
 
@@ -132,3 +133,30 @@ def test_obj2unicode():
         2     1
         3     None
     ''')
+
+def test_combining_char():
+    if sys.version >= '3':
+        abar = "a\u0304" # unicode_type
+        u_dedent = dedent
+    else:
+        abar = "a\xcc\x84" # bytes_type
+        def u_dedent(b):
+            return unicode(dedent(b), 'utf-8')
+    table = Texttable()
+    table.set_cols_align(["l", "r", "r"])
+    table.add_rows([
+        ["str", "code-point\nlength", "display\nwidth"],
+        [abar, 2, 1],
+        ["a", 1, 1],
+    ])
+    t = '''\
+        +-----+------------+---------+
+        | str | code-point | display |
+        |     |   length   |  width  |
+        +=====+============+=========+
+        | %s   |          2 |       1 |
+        +-----+------------+---------+
+        | a   |          1 |       1 |
+        +-----+------------+---------+
+    ''' % abar
+    assert clean(table.draw()) == u_dedent(t)

--- a/texttable.py
+++ b/texttable.py
@@ -106,7 +106,7 @@ frinkelpi:
 
 import sys
 import string
-import unicodedata
+import wcwidth
 
 try:
     if sys.version >= '2.3':
@@ -148,13 +148,8 @@ def obj2unicode(obj):
 def len(iterable):
     """Redefining len here so it will be able to work with non-ASCII characters
     """
-    if isinstance(iterable, bytes_type) or isinstance(iterable, unicode_type):
-        unicode_data = obj2unicode(iterable)
-        if hasattr(unicodedata, 'east_asian_width'):
-            w = unicodedata.east_asian_width
-            return sum([w(c) in 'WF' and 2 or 1 for c in unicode_data])
-        else:
-            return unicode_data.__len__()
+    if isinstance(iterable, (bytes_type, unicode_type)):
+        return wcwidth.wcswidth(iterable)
     else:
         return iterable.__len__()
 


### PR DESCRIPTION
Add support for combining characters of Unicode.

This patch uses wcwidth package to compute width of characters,
in order to render strings including combining characters such as  "ā".

E.g., the code:

```
from texttable import Texttable
table = Texttable()
table.set_cols_align(["l", "r", "r"])
table.add_rows([
    ["str", "code-point\nlength", "display\nwidth"],
    ["a\u0304", 2, 1],
    ["a", 1, 1],
])
print(table.draw())
```

will output:

```
+-----+------------+---------+
| str | code-point | display |
|     |   length   |  width  |
+=====+============+=========+
| ā   |          2 |       1 |
+-----+------------+---------+
| a   |          1 |       1 |
+-----+------------+---------+
```

Regards,