### PR TITLE
Extended cell-formatting support (w/testcase)

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -63,6 +63,36 @@ def test_texttable_header():
         opqrstu    0.023   5.000e+78    92   1.280e+22
     ''')
 
+
+def test_texttable_cell_fmt():
+    table = Texttable()
+    table.set_deco(Texttable.HEADER)
+    table.set_cols_dtype([
+        't',  # text
+        'f',  # float (decimal)
+        'e',  # float (exponent)
+        'i',  # integer
+        'a',  # automatic
+    ])
+    table.set_cell_formatter( lambda x, y, cell: cell+'s' if (x == 2  and y != 0) else cell)
+    table.set_cols_align(["l", "r", "r", "r", "l"])
+    table.add_rows([
+        ["text",    "float", "exp", "int", "auto"],
+        ["abcd",    "67",    654,   89,    128.001],
+        ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
+        ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
+        ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000],
+    ])
+    assert clean(table.draw()) == dedent('''\
+         text     float       exp       int     auto
+        ===============================================
+        abcd      67.000   6.540e+02s    89   128.001
+        efghijk   67.543   6.540e-01s    90   1.280e+22
+        lmn        0.000   5.000e-78s    89   0.000
+        opqrstu    0.023   5.000e+78s    92   1.280e+22
+    ''')
+
+
 def test_set_cols_width():
     table = Texttable()
     table.set_deco(Texttable.HEADER)


### PR DESCRIPTION
Enhances table allowing custom formatting of cells by giving you a
callback function to modify the final cell output before rendering.

In this way, you can enjoy the formatting you selected and customize it
further, for example, consider you have to display seconds with decimal
part and want to "decorate" the number with a final "s" in order to make
it explicit. Easy, pass a function like this:

    def all_but_headers(x, y, cell):
        if y==0: # headers
            return cell
        return cell+"s"

 Everything else will work as always.

 I've chosen to make the y coordinate to mean *always* the header line
 (whenever it be present or not) and all rows will be numbered from 1
 on. Columns will be zero based.

 As I'm unsure about whether or not you want to keep it compatible with
 python 2.1, I've added a kind-of enumerate compatible function enum(..)
 which should be compatible but doesn't need generators or anything
 else.
 It can be used in the future to "simplify" expressions like this:
 `for part, i in zip(X, list(range(len(X))))`