### PR TITLE
Allow User-defined data-types in `Texttable.set_cols_dtype`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ DESCRIPTION
         | Bourgeau |     |   Loue   |
         +----------+-----+----------+
 
-        text   float       exp      int     auto
-        ===========================================
-        abcd   67.000   6.540e+02   89    128.001
-        efgh   67.543   6.540e-01   90    1.280e+22
-        ijkl   0.000    5.000e-78   89    0.000
-        mnop   0.023    5.000e+78   92    1.280e+22
+         text     float       exp      int     auto
+        ==============================================
+        abcd      67.000   6.540e+02    89   128.001
+        efghijk   67.543   6.540e-01    90   1.280e+22
+        lmn        0.000   5.000e-78    89   0.000
+        opqrstu    0.023   5.000e+78    92   1.280e+22
 
 CLASSES
     class Texttable
@@ -129,13 +129,15 @@ CLASSES
      |  set_cols_dtype(self, array)
      |      Set the desired columns datatype for the cols.
      |
-     |      - the elements of the array should be either "a", "t", "f", "e" or "i":
+     |      - the elements of the array should be either a callable or any of:
+     |        "a", "t", "f", "e" or "i":
      |
      |          * "a": automatic (try to use the most appropriate datatype)
      |          * "t": treat as text
      |          * "f": treat as float in decimal format
      |          * "e": treat as float in exponential format
      |          * "i": treat as int
+     |          * a callable: should return formatted string for any value given
      |
      |      - by default, automatic datatyping is used for each column
      |

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,12 @@ import sys
 from textwrap import dedent
 from texttable import Texttable
 
+if sys.version >= '3':
+    u_dedent = dedent
+else:
+    def u_dedent(b):
+       return unicode(dedent(b), 'utf-8')
+
 def clean(text):
     return re.sub(r'( +)$', '', text, flags=re.MULTILINE) + '\n'
 
@@ -133,11 +139,6 @@ def test_obj2unicode():
     ''')
 
 def test_combining_char():
-    if sys.version >= '3':
-        u_dedent = dedent
-    else:
-        def u_dedent(b):
-           return unicode(dedent(b), 'utf-8')
     table = Texttable()
     table.set_cols_align(["l", "r", "r"])
     table.add_rows([
@@ -157,11 +158,6 @@ def test_combining_char():
     ''')
 
 def test_combining_char2():
-    if sys.version >= '3':
-        u_dedent = dedent
-    else:
-        def u_dedent(b):
-           return unicode(dedent(b), 'utf-8')
     table = Texttable()
     table.add_rows([
         ["a", "b", "c"],
@@ -173,4 +169,30 @@ def test_combining_char2():
         +--------+-----+--------+
         | 诶诶诶 | bbb | 西西西 |
         +--------+-----+--------+
+    ''')
+
+
+def test_user_dtype():
+    table = Texttable()
+
+    table.set_cols_align(["l", "r", "r"])
+    table.set_cols_dtype([
+        'a',  # automatic
+        lambda s:str(s)+"s", # user-def
+        lambda s:('%s'%s) if s>=0 else '[%s]'%(-s),  # user-def
+    ])
+    table.add_rows([
+        ["str", "code-point\nlength", "display\nwidth"],
+        ["a", 2, 1],
+        ["a", 1,-3],
+    ])
+    assert clean(table.draw()) == u_dedent('''\
+        +-----+------------+---------+
+        | str | code-point | display |
+        |     |   length   |  width  |
+        +=====+============+=========+
+        | a   |         2s |       1 |
+        +-----+------------+---------+
+        | a   |         1s |     [3] |
+        +-----+------------+---------+
     ''')

--- a/texttable.py
+++ b/texttable.py
@@ -393,6 +393,7 @@ class Texttable:
             i - index of the cell datatype in self._dtype
             x - cell data to format
         """
+        n = self._precision
         dtype = self._dtype[i]
         if callable(dtype):
             return dtype(x)
@@ -401,9 +402,6 @@ class Texttable:
             f = float(x)
         except:
             return obj2unicode(x)
-
-        n = self._precision
-        dtype = self._dtype[i]
 
         if dtype == 'i':
             return str(int(round(f)))

--- a/texttable.py
+++ b/texttable.py
@@ -393,6 +393,10 @@ class Texttable:
             i - index of the cell datatype in self._dtype
             x - cell data to format
         """
+        dtype = self._dtype[i]
+        if callable(dtype):
+            return dtype(x)
+
         try:
             f = float(x)
         except:

--- a/texttable.py
+++ b/texttable.py
@@ -272,13 +272,15 @@ class Texttable:
     def set_cols_dtype(self, array):
         """Set the desired columns datatype for the cols.
 
-        - the elements of the array should be either "a", "t", "f", "e" or "i":
+        - the elements of the array should be either a callable or any of "a",
+          "t", "f", "e" or "i":
 
             * "a": automatic (try to use the most appropriate datatype)
             * "t": treat as text
             * "f": treat as float in decimal format
             * "e": treat as float in exponential format
             * "i": treat as int
+            * a callable: should return formatted string for any value given
 
         - by default, automatic datatyping is used for each column
         """


### PR DESCRIPTION
After discussion in #23 I've realized that `Texttable` was actually already supporting column formatting, but its support was quite limited.

It become clear that supporting column formatting actually *is* an wanted feature.

With two lines of code we enable user to use its own column formatting function using existing API, and open the door to a few more improvements in code.