### PR TITLE
Easier formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ DESCRIPTION
         | Bourgeau |     |   Loue   |
         +----------+-----+----------+
 
-        text   float       exp      int     auto
-        ===========================================
-        abcd   67.000   6.540e+02   89    128.001
-        efgh   67.543   6.540e-01   90    1.280e+22
-        ijkl   0.000    5.000e-78   89    0.000
-        mnop   0.023    5.000e+78   92    1.280e+22
+         text     float       exp      int     auto
+        ==============================================
+        abcd      67.000   6.540e+02    89   128.001
+        efghijk   67.543   6.540e-01    90   1.280e+22
+        lmn        0.000   5.000e-78    89   0.000
+        opqrstu    0.023   5.000e+78    92   1.280e+22
 
 CLASSES
     class Texttable
@@ -129,13 +129,15 @@ CLASSES
      |  set_cols_dtype(self, array)
      |      Set the desired columns datatype for the cols.
      |
-     |      - the elements of the array should be either "a", "t", "f", "e" or "i":
+     |      - the elements of the array should be either a callable or any of:
+     |        "a", "t", "f", "e" or "i":
      |
      |          * "a": automatic (try to use the most appropriate datatype)
      |          * "t": treat as text
      |          * "f": treat as float in decimal format
      |          * "e": treat as float in exponential format
      |          * "i": treat as int
+     |          * a callable: should return formatted string for any value given
      |
      |      - by default, automatic datatyping is used for each column
      |

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,12 @@ import sys
 from textwrap import dedent
 from texttable import Texttable
 
+if sys.version >= '3':
+    u_dedent = dedent
+else:
+    def u_dedent(b):
+       return unicode(dedent(b), 'utf-8')
+
 def clean(text):
     return re.sub(r'( +)$', '', text, flags=re.MULTILINE) + '\n'
 
@@ -133,11 +139,6 @@ def test_obj2unicode():
     ''')
 
 def test_combining_char():
-    if sys.version >= '3':
-        u_dedent = dedent
-    else:
-        def u_dedent(b):
-           return unicode(dedent(b), 'utf-8')
     table = Texttable()
     table.set_cols_align(["l", "r", "r"])
     table.add_rows([
@@ -157,11 +158,6 @@ def test_combining_char():
     ''')
 
 def test_combining_char2():
-    if sys.version >= '3':
-        u_dedent = dedent
-    else:
-        def u_dedent(b):
-           return unicode(dedent(b), 'utf-8')
     table = Texttable()
     table.add_rows([
         ["a", "b", "c"],
@@ -173,4 +169,30 @@ def test_combining_char2():
         +--------+-----+--------+
         | 诶诶诶 | bbb | 西西西 |
         +--------+-----+--------+
+    ''')
+
+
+def test_user_dtype():
+    table = Texttable()
+
+    table.set_cols_align(["l", "r", "r"])
+    table.set_cols_dtype([
+        'a',  # automatic
+        lambda s:str(s)+"s", # user-def
+        lambda s:('%s'%s) if s>=0 else '[%s]'%(-s),  # user-def
+    ])
+    table.add_rows([
+        ["str", "code-point\nlength", "display\nwidth"],
+        ["a", 2, 1],
+        ["a", 1,-3],
+    ])
+    assert clean(table.draw()) == u_dedent('''\
+        +-----+------------+---------+
+        | str | code-point | display |
+        |     |   length   |  width  |
+        +=====+============+=========+
+        | a   |         2s |       1 |
+        +-----+------------+---------+
+        | a   |         1s |     [3] |
+        +-----+------------+---------+
     ''')

--- a/texttable.py
+++ b/texttable.py
@@ -393,6 +393,7 @@ class Texttable:
             i - index of the cell datatype in self._dtype
             x - cell data to format
         """
+        n = self._precision
         dtype = self._dtype[i]
         if callable(dtype):
             return dtype(x)
@@ -401,9 +402,6 @@ class Texttable:
             f = float(x)
         except:
             return obj2unicode(x)
-
-        n = self._precision
-        dtype = self._dtype[i]
 
         if dtype == 'i':
             return str(int(round(f)))

--- a/texttable.py
+++ b/texttable.py
@@ -444,12 +444,14 @@ class Texttable:
     def _fmt_auto(cls, x, **kw):
         """auto formatting class-method."""
         f = cls._to_float(x)
-
         if abs(f) > 1e8:
-            return cls._fmt_exp(x, **kw)
-        if f - round(f) == 0:
-            return cls._fmt_int(x, **kw)
-        return cls._fmt_float(x, **kw)
+            fn = cls._fmt_exp
+        else:
+            if f - round(f) == 0:
+                fn = cls._fmt_int
+            else:
+                fn = cls._fmt_float
+        return fn(x, **kw)
 
     def _str(self, i, x):
         """Handles string formatting of cell data

--- a/texttable.py
+++ b/texttable.py
@@ -426,7 +426,7 @@ class Texttable:
         return '%.*e' % (n, f)
 
     @classmethod
-    def _fmt_obj(cls, x, **kw):
+    def _fmt_text(cls, x, **kw):
         """String formatting class-method.
         """
         return obj2unicode(x)
@@ -438,7 +438,7 @@ class Texttable:
         n = kw.pop('n')
         f = kw.pop('f', None)
         if f is None:
-            return obj2unicode(x)
+            return cls._fmt_text(x)
 
         if abs(f) > 1e8:
             return cls._fmt_exp(x, f=f, n=n)
@@ -458,7 +458,7 @@ class Texttable:
             'i':self._fmt_int,
             'f':self._fmt_float,
             'e':self._fmt_exp,
-            't':self._fmt_obj,
+            't':self._fmt_text,
             }
 
         n = self._precision

--- a/texttable.py
+++ b/texttable.py
@@ -393,6 +393,10 @@ class Texttable:
             i - index of the cell datatype in self._dtype
             x - cell data to format
         """
+        dtype = self._dtype[i]
+        if callable(dtype):
+            return dtype(x)
+
         try:
             f = float(x)
         except:


### PR DESCRIPTION
This includes my previous PR .

But also, gives the user the chance to write its own formatting-cell functions and reuse/fallback to class already defined formatting ones.

Formatting function signature being reduced not including `f` which could be easily re-calculated when/if needed

`n` precision parameter can be accessed from `**kw` argument if required.

Code is readable and reusable.

