### PR TITLE
Run unit tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: python
 
-# Supported CPython versions:
-# https://en.wikipedia.org/wiki/CPython#Version_history
 python:
- - pypy3
- - pypy
- - 2.7
- - 3.6
- - 3.5
- - 3.4
+ - "3.6"
+ - "3.5"
+ - "2.7"
 
 sudo: false
 
 install:
- - pip install pyflakes pycodestyle
+ - pip install pycodestyle pyflakes tox-travis
 
 script:
+ # Tests
+ - tox
+
+after_script:
  # Static analysis
  - pyflakes .
  - pycodestyle --statistics --count .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 sudo: false
 
 install:
- - pip install pycodestyle pyflakes tox-travis
+ - pip install tox-travis
 
 script:
  # Tests
@@ -16,8 +16,13 @@ script:
 
 after_script:
  # Static analysis
+ - pip install pycodestyle pyflakes
  - pyflakes .
  - pycodestyle --statistics --count .
+
+after_success:
+ - pip install codecov
+ - codecov
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+
+# Supported CPython versions:
+# https://en.wikipedia.org/wiki/CPython#Version_history
+python:
+ - pypy3
+ - pypy
+ - 2.7
+ - 3.6
+ - 3.5
+ - 3.4
+
+sudo: false
+
+install:
+ - pip install pyflakes pycodestyle
+
+script:
+ # Static analysis
+ - pyflakes .
+ - pycodestyle --statistics --count .
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
PR #13 added unit tests, it's a good idea to run them on a CI to make sure new changes don't break anything.

Please enable Travis for this repo at https://travis-ci.org/profile/, it's free for open-source projects.

This runs the unit tests in the `script` section. Failures here will fail the build.

Then in the `after_script` section, it does some static analysis. But this is for info only as section won't fail the build if it finds thing.

In then sends coverage info to Codecov to be able to check the coverage is kept up.

Here's an example run: https://travis-ci.org/hugovk/texttable/builds/301948539
Here's an example coverage report: https://codecov.io/gh/hugovk/texttable/tree/973dc0047a58e6e4b2cc7491033db1f29e5f5807