### PR TITLE
Remove redundant code for unsupported/EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: python
 
-# Supported CPython versions:
-# https://en.wikipedia.org/wiki/CPython#Version_history
 python:
- - pypy3
- - pypy
- - 2.7
- - 3.6
- - 3.5
- - 3.4
+ - "3.6"
+ - "3.5"
+ - "2.7"
 
 sudo: false
 
 install:
- - pip install pyflakes pycodestyle
+ - pip install pycodestyle pyflakes tox-travis
 
 script:
+ # Tests
+ - tox
+
+after_script:
  # Static analysis
  - pyflakes .
  - pycodestyle --statistics --count .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 sudo: false
 
 install:
- - pip install pycodestyle pyflakes tox-travis
+ - pip install tox-travis
 
 script:
  # Tests
@@ -16,8 +16,13 @@ script:
 
 after_script:
  # Static analysis
+ - pip install pycodestyle pyflakes
  - pyflakes .
  - pycodestyle --statistics --count .
+
+after_success:
+ - pip install codecov
+ - codecov
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+
+# Supported CPython versions:
+# https://en.wikipedia.org/wiki/CPython#Version_history
+python:
+ - pypy3
+ - pypy
+ - 2.7
+ - 3.6
+ - 3.5
+ - 3.4
+
+sudo: false
+
+install:
+ - pip install pyflakes pycodestyle
+
+script:
+ # Static analysis
+ - pyflakes .
+ - pycodestyle --statistics --count .
+
+matrix:
+  fast_finish: true

--- a/texttable.py
+++ b/texttable.py
@@ -105,22 +105,10 @@ frinkelpi:
 """
 
 import sys
-import string
+import textwrap
 import unicodedata
+from functools import reduce
 
-try:
-    if sys.version_info >= (2, 3):
-        import textwrap
-    elif sys.version_info >= (2, 2):
-        from optparse import textwrap
-    else:
-        from optik import textwrap
-except ImportError:
-    sys.stderr.write("Can't import textwrap module!\n")
-    raise
-
-if sys.version_info >= (2, 7):
-    from functools import reduce
 
 if sys.version_info >= (3, 0):
     unicode_type = str
@@ -150,11 +138,9 @@ def len(iterable):
     """
     if isinstance(iterable, bytes_type) or isinstance(iterable, unicode_type):
         unicode_data = obj2unicode(iterable)
-        if hasattr(unicodedata, 'east_asian_width'):
-            w = unicodedata.east_asian_width
-            return sum([w(c) in 'WF' and 2 or (0 if unicodedata.combining(c) else 1) for c in unicode_data])
-        else:
-            return unicode_data.__len__()
+        w = unicodedata.east_asian_width
+        return sum([w(c) in 'WF' and 2 or (
+            0 if unicodedata.combining(c) else 1) for c in unicode_data])
     else:
         return iterable.__len__()
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ envlist = py27,py35,py36
 deps =
     pytest
     pytest-cov
-commands = py.test --cov-report=term-missing --cov=texttable tests.py
+commands = pytest --cov-report=term-missing --cov=texttable tests.py


### PR DESCRIPTION
Includes PR #29.

setup.py claims support for Python 2.7, 3.5 and 3.6.

Anything before 2.7 is EOL and unsupported by the Python core team, and no longer receiving security updates. So remove redundant code for those.