### PR TITLE
Show long description with Markdown on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,8 @@
 
 DESCRIPTION = "module for creating simple ASCII tables"
 
-LONG_DESCRIPTION = """\
-texttable is a module to generate a formatted text table, using ASCII
-characters."""
+with open("README.md") as f:
+    LONG_DESCRIPTION = f.read()
 
 import sys
 
@@ -42,6 +41,7 @@ setup(
     py_modules = ["texttable"],
     description = DESCRIPTION,
     long_description = LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
     platforms = "any",
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
The new PyPI (aka Warehouse) now supports Markdown for the long description.

More info and examples:

* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example
* https://pypi.org/project/markdown-description-example/