### PR TITLE
Exclude non-runnable code from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:


### PR DESCRIPTION
From #30, but this change does not require Travis CI.

Exclude the `__main__` section from test coverage because that's not runnable from unit tests.

This bumps up coverage to 90.78%.