### PR TITLE
Use setuptools instead of distutils to upload metadata to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,27 +17,27 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+from setuptools import setup
+
 DESCRIPTION = "module for creating simple ASCII tables"
 
 with open("README.md") as f:
     LONG_DESCRIPTION = f.read()
 
-from setuptools import setup
-
 setup(
-    name = "texttable",
-    version = "1.4.0",
-    author = "Gerome Fournier",
-    author_email = "jef@foutaise.org",
-    url = "https://github.com/foutaise/texttable/",
-    download_url = "https://github.com/foutaise/texttable/archive/v1.4.0.tar.gz",
-    license = "LGPL",
-    py_modules = ["texttable"],
-    description = DESCRIPTION,
-    long_description = LONG_DESCRIPTION,
+    name="texttable",
+    version="1.4.0",
+    author="Gerome Fournier",
+    author_email="jef@foutaise.org",
+    url="https://github.com/foutaise/texttable/",
+    download_url="https://github.com/foutaise/texttable/archive/v1.4.0.tar.gz",
+    license="LGPL",
+    py_modules=["texttable"],
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
-    platforms = "any",
-    classifiers = [
+    platforms="any",
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,8 @@ DESCRIPTION = "module for creating simple ASCII tables"
 with open("README.md") as f:
     LONG_DESCRIPTION = f.read()
 
-import sys
+from setuptools import setup
 
-from distutils.core import setup
 setup(
     name = "texttable",
     version = "1.4.0",


### PR DESCRIPTION
I noticed that on PyPI the full description and classifiers aren't shown:

https://pypi.org/project/texttable/

I think this is because the older distutils is being used for upload to PyPI rather than the newer setuptools. See https://stackoverflow.com/a/25372045/724176.

Here's a _test_ upload to Test PyPI using setuptools that shows the full description and all the classifiers:

https://test.pypi.org/project/texttable/


And here's how I usually upload to PyPI (you might not need all of this):
```
pip install -U pip setuptools wheel twine keyring
python setup.py sdist --format=gztar bdist_wheel
twine upload -r test dist/texttable-1.4.0*
```