### PR TITLE
Fix typo and update link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python module for creating simple ASCII tables
 
 ## Availability
 
-This module is available on [PypI](https://pypi.python.org/pypi/texttable/1.4.0), and has been packaged for several Linux/Unix platforms
+This module is available on [PyPI](https://pypi.org/project/texttable/), and has been packaged for several Linux/Unix platforms
 ([Debian](https://packages.debian.org/search?&searchon=names&keywords=python-texttable+),
 [FreeBSD](https://www.freebsd.org/cgi/ports.cgi?query=texttable&stype=all), Fedora, Suse...).
 


### PR DESCRIPTION
* Fix PyPI typo
* Update link to point to latest release, not a given release number
* Update like to match redirect