### PR TITLE
Run tests on Travis CI and send coverage to Codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.cache/
 /.coverage
+/.pytest_cache/
 /.tox/
 /MANIFEST
 /__pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+cache: pip
+
+matrix:
+  fast_finish: true
+  include:
+    - python: '2.7'
+    - python: '3.5'
+    - python: '3.6'
+    - python: '3.7'
+      dist: xenial
+      sudo: required
+
+install:
+ - pip install -U coverage tox-travis
+
+script:
+ - tox
+
+after_success:
+ - coverage report
+ - pip install -U codecov
+ - codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # texttable
 
+[![Build Status](https://travis-ci.org/foutaise/texttable.svg?branch=master)](https://travis-ci.org/foutaise/texttable)
+
 Python module for creating simple ASCII tables
 
 ## Availability

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps =


### PR DESCRIPTION
This adds the config to run the tests on Travis CI, and send coverage reports to Codecov.

Both services are free for open source, please create accounts on them.

The CI will run for all commits pushed, and also for PRs, meaning you can automatically see if tests pass for the supported Python versions before merging, and whether coverage drops. It's currently at 91.59% which is really good.

Examples:
* https://travis-ci.org/hugovk/texttable/builds/428938865
* https://codecov.io/gh/hugovk/texttable/tree/54f24234a986683b539ef1a53bf2f1a80eb2a663

This also adds a build badge to the README. There's a small workaround for Python 3.7 in .travis.yml, which needs Xenial and sudo, see https://github.com/travis-ci/travis-ci/issues/9815.