### PR TITLE
Fix auto-formatting NaN

### DIFF
--- a/texttable.py
+++ b/texttable.py
@@ -483,11 +483,12 @@ class Texttable:
         f = cls._to_float(x)
         if abs(f) > 1e8:
             fn = cls._fmt_exp
+        elif f != f:  # NaN
+            fn = cls._fmt_text
+        elif f - round(f) == 0:
+            fn = cls._fmt_int
         else:
-            if f - round(f) == 0:
-                fn = cls._fmt_int
-            else:
-                fn = cls._fmt_float
+            fn = cls._fmt_float
         return fn(x, **kw)
 
     def _str(self, i, x):


### PR DESCRIPTION
Current version fails with error

    ValueError: cannot convert float NaN to integer

This is because `round(float('nan'))` does not work. This pull request adds a special check to auto formatter and uses text format for `NaN` instead (string 'NaN').
Maybe it would be better to display an empty field though (`fn = lambda x,**kw: ''`)?

---

I would like to open the discussion to implement an additional argument for a NaN-formatter which could be a function to convert Nan to string.