### PR TITLE
Add Latex drawing functionality.

### DIFF
--- a/texttable.py
+++ b/texttable.py
@@ -92,6 +92,7 @@ frinkelpi:
 
 import sys
 import unicodedata
+import texttable_latex
 
 # define a text wrapping function to wrap some text
 # to a specific width:
@@ -431,6 +432,18 @@ class Texttable:
             out += self._hline()
         return out[:-1]
 
+    def draw_latex(self, caption=None, label=None, drop_columns=None):
+        """Draw the table in Latex format
+
+        - The 'caption' argument is a string that adds a caption to the Latex formatting.
+        - The 'label' argument is a string that adds a referencing label to the Latex formatting.
+        - The 'drop_columns' argument is an array of column names that won't be in the Latex output.
+          Each column name must be in the table header.
+
+        - The formatted table is returned as a whole string
+        """
+        return texttable_latex.draw(self, caption, label, drop_columns)
+
     @classmethod
     def _to_float(cls, x):
         if x is None:
@@ -724,6 +737,7 @@ if __name__ == '__main__':
                     ["Mr\nBaptiste\nClement", 1, "Baby"],
                     ["Mme\nLouise\nBourgeau", 28, "Lou\n \nLoue"]])
     print(table.draw() + "\n")
+    print(table.draw_latex(caption="An example table.", label="table:example_table") + "\n")
 
     table = Texttable()
     table.set_deco(Texttable.HEADER)
@@ -738,4 +752,6 @@ if __name__ == '__main__':
                     ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
                     ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
                     ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000]])
-    print(table.draw())
+    print(table.draw() + "\n")
+    print(table.draw_latex(caption="Another table.", label="table:another_table") + "\n")
+    print(table.draw_latex(caption="A table with dropped columns.", label="table:dropped_column_table", drop_columns=['exp', 'int']))

--- a/texttable_latex.py
+++ b/texttable_latex.py
@@ -1,0 +1,184 @@
+"""
+Drawing functions for outputting a table in a Latex format.
+"""
+
+
+class DropColumnError(Exception):
+
+    def __init__(self, column, header):
+        super().__init__("Cannot drop column {:s} - column not in table header ({:s})\n".format(column, str(header)))
+
+
+def draw(table, caption, label, drop_columns):
+    """Draw the table in Latex format
+
+    - The 'caption' argument is a string that adds a caption to the Latex formatting.
+    - The 'label' argument is a string that adds a referencing label to the Latex formatting.
+    - The 'drop_columns' argument is an array of column names that won't be in the Latex output.
+      Each column name must be in the table header.
+
+    - The formatted table is returned as a whole string
+    """
+    _sanitise_drop_columns(table._header, drop_columns)
+    out = ""
+    out += _draw_latex_preamble(table)
+    out += _draw_latex_header(table, drop_columns)
+    out += _draw_latex_content(table, drop_columns)
+    out += _draw_latex_postamble(table, caption, label)
+    return out
+
+
+def _draw_latex_preamble(table):
+    """Draw the Latex table preamble.
+
+    - Applies column horizontal alignment
+    - Applies columns vlines and table vertical border if appropriate.
+
+    Example Output:
+        \begin{table}
+            \begin{center}
+                \begin{tabular}{|l|r|c|}
+    """
+    out = "\\begin{table}\n"
+    out += _indent_text("\\begin{center}\n", 1)
+
+    # Column setup with/without vlines
+    if table._has_vlines():
+        column_str = "|".join(table._align)
+    else:
+        column_str = " ".join(table._align)
+
+    # Border with/without edges
+    if table._has_border():
+        tabular_str = "\\begin{tabular}{|" + column_str + "|}\n"
+    else:
+        tabular_str = "\\begin{tabular}{" + column_str + "}\n"
+    out += _indent_text(tabular_str, 2)
+
+    return out
+
+
+def _draw_latex_header(table, drop_columns):
+    """Draw the Latex header.
+
+    - Applies header border if appropriate.
+
+    Example Output:
+        \hline
+        Name & Age & Nickname \\
+        \hline
+    """
+    out = ""
+    if table._has_border():
+        out += _indent_text("\\hline\n", 3)
+
+    # Drop header columns if required
+    header = _drop_columns(table._header.copy(), table._header, drop_columns)
+    out += _indent_text(" & ".join(header) + " \\\\\n", 3)
+
+    if table._has_header():
+        out += _indent_text("\\hline\n", 3)
+    return out
+
+
+def _draw_latex_content(table, drop_columns):
+    """Draw the Latex table content.
+
+    - Applies table hlines if appropriate.
+
+    Example Output:
+        MrXavierHuon & 32 & Xav' \\
+        \hline
+        MrBaptisteClement & 1 & Baby \\
+        \hline
+        MmeLouiseBourgeau & 28 & Lou Loue \\
+    """
+    out = ""
+    for idx, row in enumerate(table._rows):
+        row = _drop_columns(row, table._header, drop_columns)
+        clean_row = _clean_row(row)
+        out += _indent_text(" & ".join(clean_row) + " \\\\\n", 3)
+        if table._has_hlines() and idx != len(table._rows) - 1:
+            out += _indent_text("\\hline\n", 3)
+    return out
+
+
+def _draw_latex_postamble(table, caption, label):
+    """Draw the Latex table postamble.
+
+    - Adds caption and label if given.
+    - Applies table bottom border if appropriate.
+
+    Example Output:
+                \hline
+                \end{tabular}
+            \end{center}
+            \caption{An example table.}
+            \label{table:example_table}
+        \end{table}
+    """
+    out = ""
+    if table._has_border():
+        out += _indent_text("\\hline\n", 3)
+    out += _indent_text("\\end{tabular}\n", 2)
+    out += _indent_text("\\end{center}\n", 1)
+    if caption is not None:
+        out += _indent_text("\\caption{" + caption + "}\n", 1)
+    if label is not None:
+        out += _indent_text("\\label{" + label + "}\n", 1)
+    out += "\\end{table}"
+    return out
+
+
+def _clean_row(row):
+    """Clean a row prior to drawing.
+
+    - Removes newlines.
+    """
+    clean_row = []
+    for element in row:
+        clean_row.append(element.replace("\n", ""))
+    return clean_row
+
+
+def _sanitise_drop_columns(header, drop_columns):
+    """Check the columns to be dropped.
+
+    - Each column to be dropped must be in the header.
+    """
+    if drop_columns is None:
+        return
+    # Check columns (ignores case).
+    for column in drop_columns:
+        if column.upper() not in [h.upper() for h in header]:
+            raise DropColumnError(column, header)
+
+
+def _drop_columns(target, header, drop_columns):
+    """Drop columns from a target array.
+
+    - The 'target' argument is the array from which the columns should be dropped.
+    - The 'header' argument is the table header.
+      This is used to identify the column index in target that should be dropped.
+    - 'drop_columns' specifies which columns should be dropped. Each column should be in the header.
+    """
+    if drop_columns is None:
+        return target
+    # Get indices to delete
+    to_delete = []
+    for column in drop_columns:
+        column_idx = header.index(column)
+        to_delete.append(column_idx)
+    # Delete relevant indices (in reverse order so deletion doesn't affect other index positions)
+    for i in sorted(to_delete, reverse=True):
+        del target[i]
+    return target
+
+
+def _indent_text(text, indent):
+    """Indent a string by a certain number of tabs.
+
+    - 'text' is the text to be indented
+    - 'indent' is the number of tabs to prepend to the string.
+    """
+    return '\t' * indent + text


### PR DESCRIPTION
Adds the ability to draw tables in a Latex format.

### Motivation
I often want to export my Texttable outputs to Latex. This leads to a tedious chore of reformatting the table content in Latex. To solve this problem, this pull request adds the ability to output tables straight to a Latex format that mirrors the Texttable output. Sometimes my tables contain extra columns that are useful in development but are not required in the Latex report, therefore I included the ability to drop columns for the Latex output.

### Features
- Draw a table object in a Latex format.
- Matches table deco (border, header, hlines, vlines).
- Applies horizontal column alignment.
- Allows the user to drop certain columns from the output.
- Provides the ability to add a caption and reference label to the Latex output.
- The output is correctly indented for directly copying into Latex.

### Examples
These examples use the existing tables provided in the docs.

Usage:

```
table = Texttable()
table.set_cols_align(["l", "r", "c"])
table.set_cols_valign(["t", "m", "b"])
table.add_rows([["Name", "Age", "Nickname"],
                ["Mr\nXavier\nHuon", 32, "Xav'"],
                ["Mr\nBaptiste\nClement", 1, "Baby"],
                ["Mme\nLouise\nBourgeau", 28, "Lou\n \nLoue"]])
print(table.draw() + "\n")
print(table.draw_latex(caption="An example table.", label="table:example_table") + "\n")

table = Texttable()
table.set_deco(Texttable.HEADER)
table.set_cols_dtype(['t',  # text
                      'f',  # float (decimal)
                      'e',  # float (exponent)
                      'i',  # integer
                      'a']) # automatic
table.set_cols_align(["l", "r", "r", "r", "l"])
table.add_rows([["text",    "float", "exp", "int", "auto"],
                ["abcd",    "67",    654,   89,    128.001],
                ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
                ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
                ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000]])
print(table.draw() + "\n")
print(table.draw_latex(caption="Another table.", label="table:another_table") + "\n")
print(table.draw_latex(caption="A table with dropped columns.", label="table:dropped_column_table", drop_columns=['exp', 'int']))
```

Latex output:

```
\begin{table}
	\begin{center}
		\begin{tabular}{|l|r|c|}
			\hline
			Name & Age & Nickname \\
			\hline
			MrXavierHuon & 32 & Xav' \\
			\hline
			MrBaptisteClement & 1 & Baby \\
			\hline
			MmeLouiseBourgeau & 28 & Lou Loue \\
			\hline
		\end{tabular}
	\end{center}
	\caption{An example table.}
	\label{table:example_table}
\end{table}

\begin{table}
	\begin{center}
		\begin{tabular}{l r r r l}
			text & float & exp & int & auto \\
			\hline
			abcd & 67.000 & 6.540e+02 & 89 & 128.001 \\
			efghijk & 67.543 & 6.540e-01 & 90 & 1.280e+22 \\
			lmn & 0.000 & 5.000e-78 & 89 & 0.000 \\
			opqrstu & 0.023 & 5.000e+78 & 92 & 1.280e+22 \\
		\end{tabular}
	\end{center}
	\caption{Another table.}
	\label{table:another_table}
\end{table}

\begin{table}
	\begin{center}
		\begin{tabular}{l r r r l}
			text & float & auto \\
			\hline
			abcd & 67.000 & 128.001 \\
			efghijk & 67.543 & 1.280e+22 \\
			lmn & 0.000 & 0.000 \\
			opqrstu & 0.023 & 1.280e+22 \\
		\end{tabular}
	\end{center}
	\caption{A table with dropped columns.}
	\label{table:dropped_column_table}
\end{table}
```

Latex rendering:
![example_outputs](https://user-images.githubusercontent.com/7620667/83984754-87ca6700-a92e-11ea-98f6-250833ea867c.png)

### Implementation details
I wrote the main drawing functions is a separate Python file `texttable_latex.py` to improve code readability. The `texttable.py` file has been altered to include a new `draw_latex` function that calls the drawing functions in `texttable_latex.py`. I've also added example outputs in `texttable.py`.

I wanted to avoid adding too many kwargs to the `draw_latex` method; this could quickly get out of hand for the number of different ways one can style tables in Latex. Instead, my aim was to produce the boilerplate Latex code and mimic the Texttable styling. The user can then tweak the Latex output later on to suit their particular needs. However, I have included the ability to add captions and labels as they are a pretty fundamental part of Latex tables.

### ToDos

I'm happy to write the relevant tests for my new features, and add any bits that people think are appropriate. I wanted to open this PR early to see if there was any interest in this feature. 

I've attempted to follow the existing documentation style as closely as possible - I'll change it up or add more comments if required.
