### PR TITLE
README: Python 3 print() function, English typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ DESCRIPTION
                         ["Mr\nXavier\nHuon", 32, "Xav'"],
                         ["Mr\nBaptiste\nClement", 1, "Baby"],
                         ["Mme\nLouise\nBourgeau", 28, "Lou\n\nLoue"]])
-        print table.draw() + "\n"
+        print(table.draw())
+        print()
 
         table = Texttable()
         table.set_deco(Texttable.HEADER)
@@ -49,7 +50,7 @@ DESCRIPTION
                         ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
                         ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
                         ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000]])
-        print table.draw()
+        print(table.draw())
 
     Result:
 
@@ -167,7 +168,7 @@ CLASSES
      |  set_deco(self, deco)
      |      Set the table decoration
      |
-     |      - 'deco' can be a combinaison of:
+     |      - 'deco' can be a combination of:
      |
      |          Texttable.BORDER: Border around the table
      |          Texttable.HEADER: Horizontal line below the header


### PR DESCRIPTION
`print table.draw()` only works in Python 2, which is obsolete