### PR TITLE
Add experimental color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This module is available on [PyPI](https://pypi.org/project/texttable/), and has
 
 ## Dependencies
 
+If color is desired (see below), [ansiwrap](https://github.com/jonathaneunice/ansiwrap) library should be installed.
+
 If available, [cjkwrap](https://github.com/fgallaire/cjkwrap) library is used instead of textwrap, for a better wrapping of CJK text.
 
 If available, [wcwidth](https://github.com/jquast/wcwidth) library is used for a better rendering (basic emoji support).
@@ -252,6 +254,14 @@ CREDITS
 
     frinkelpi:
         - preserve empty lines
+```
+
+## Experimental Features
+
+To enable experimental color support, run the following after importing texttable:
+```
+import texttable
+texttable.set_experimental_color(True)
 ```
 
 ## Forks

--- a/texttable.py
+++ b/texttable.py
@@ -91,8 +91,25 @@ frinkelpi:
     - preserve empty lines
 """
 
+import re
 import sys
 import unicodedata
+
+EXPERIMENTAL_COLOR = False
+
+def set_experimental_color(enabled):
+    global EXPERIMENTAL_COLOR
+    global textwrapper
+
+    EXPERIMENTAL_COLOR = enabled
+    if not enabled:
+        return
+    try:
+        import ansiwrap
+        textwrapper = ansiwrap.wrap
+    except ImportError:
+        sys.stderr.write("Experimental color feature enabled but ansiwrap package not installed!\n")
+        raise
 
 # define a text wrapping function to wrap some text
 # to a specific width:
@@ -160,6 +177,9 @@ def len(iterable):
     """Redefining len here so it will be able to work with non-ASCII characters
     """
     if isinstance(iterable, bytes_type) or isinstance(iterable, unicode_type):
+        if EXPERIMENTAL_COLOR and isinstance(iterable, unicode_type):
+            ansi_escape = re.compile(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]')
+            iterable = ansi_escape.sub('', iterable)
         return sum([uchar_width(c) for c in obj2unicode(iterable)])
     else:
         return iterable.__len__()


### PR DESCRIPTION
Opening this pull request in case there is interest for this. I noticed on another open issue that you left out color support intentionally, but I think this solution is small enough that you might reconsider. I labelled it "experimental" as I haven't done comprehensive testing, though it works very well for what I'm using it for (column wrap included). The only time I've seen it break down are for small (<=2 width) columns that have wrapping text.