### PR TITLE
Add boolean formatting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ CLASSES
      |          * "f": treat as float in decimal format
      |          * "e": treat as float in exponential format
      |          * "i": treat as int
+     |          * "b": treat as boolean
      |          * a callable: should return formatted string for any value given
      |
      |      - by default, automatic datatyping is used for each column

--- a/tests.py
+++ b/tests.py
@@ -50,26 +50,23 @@ def test_texttable_header():
         'f',  # float (decimal)
         'e',  # float (exponent)
         'i',  # integer
-        'b',  # boolean
         'a',  # automatic
     ])
-    table.set_cols_align(["l", "r", "r", "r", "l", "l"])
+    table.set_cols_align(["l", "r", "r", "r", "l"])
     table.add_rows([
-        ["text",    "float", "exp", "int", "bool", "auto"],
-        ["abcd",    "67",    654,   89,    True,   128.001],
-        ["efghijk", 67.5434, .654,  89.6,  42,     12800000000000000000000.00023],
-        ["lmn",     5e-78,   5e-78, 89.4,  False,  .000000000000128],
-        ["opqrstu", .023,    5e+78, 92.,   0,      12800000000000000000000],
-        ["abcdef",  .023,    5e+78, 92.,   0,      False],
+        ["text",    "float", "exp", "int", "auto"],
+        ["abcd",    "67",    654,   89,    128.001],
+        ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
+        ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
+        ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000],
     ])
     assert clean(table.draw()) == dedent('''\
-         text     float       exp      int   bool      auto
-        ======================================================
-        abcd      67.000   6.540e+02    89   True    128.001
-        efghijk   67.543   6.540e-01    90   True    1.280e+22
-        lmn        0.000   5.000e-78    89   False   0.000
-        opqrstu    0.023   5.000e+78    92   False   1.280e+22
-        abcdef     0.023   5.000e+78    92   False   False
+         text     float       exp      int     auto
+        ==============================================
+        abcd      67.000   6.540e+02    89   128.001
+        efghijk   67.543   6.540e-01    90   1.280e+22
+        lmn        0.000   5.000e-78    89   0.000
+        opqrstu    0.023   5.000e+78    92   1.280e+22
     ''')
 
 def test_set_cols_width():
@@ -305,4 +302,26 @@ def test_nan():
         +=======+
         | NaN   |
         +-------+
+    ''')
+
+def test_bool():
+    table = Texttable()
+    table.set_cols_align(["l", "l"])
+    table.set_cols_dtype(["a", "b"])
+    table.set_deco(0)
+    table.add_rows([
+        [True,   True],
+        [False,  False],
+        ["test", 0],
+        [12,     "true"],
+        [12,     ""],
+        [34.2,   1.0],
+    ], header=False)
+    assert clean(table.draw()) == u_dedent('''\
+        True     True
+        False    False
+        test     False
+        12       True
+        12       False
+        34.200   True
     ''')

--- a/tests.py
+++ b/tests.py
@@ -50,23 +50,24 @@ def test_texttable_header():
         'f',  # float (decimal)
         'e',  # float (exponent)
         'i',  # integer
+        'b',  # boolean
         'a',  # automatic
     ])
-    table.set_cols_align(["l", "r", "r", "r", "l"])
+    table.set_cols_align(["l", "r", "r", "r", "l", "l"])
     table.add_rows([
-        ["text",    "float", "exp", "int", "auto"],
-        ["abcd",    "67",    654,   89,    128.001],
-        ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
-        ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
-        ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000],
+        ["text",    "float", "exp", "int", "bool", "auto"],
+        ["abcd",    "67",    654,   89,    True,   128.001],
+        ["efghijk", 67.5434, .654,  89.6,  True,   12800000000000000000000.00023],
+        ["lmn",     5e-78,   5e-78, 89.4,  False,  .000000000000128],
+        ["opqrstu", .023,    5e+78, 92.,   False,  12800000000000000000000],
     ])
     assert clean(table.draw()) == dedent('''\
-         text     float       exp      int     auto
-        ==============================================
-        abcd      67.000   6.540e+02    89   128.001
-        efghijk   67.543   6.540e-01    90   1.280e+22
-        lmn        0.000   5.000e-78    89   0.000
-        opqrstu    0.023   5.000e+78    92   1.280e+22
+         text     float       exp      int   bool      auto
+        ======================================================
+        abcd      67.000   6.540e+02    89   True    128.001
+        efghijk   67.543   6.540e-01    90   True    1.280e+22
+        lmn        0.000   5.000e-78    89   False   0.000
+        opqrstu    0.023   5.000e+78    92   False   1.280e+22
     ''')
 
 def test_set_cols_width():

--- a/tests.py
+++ b/tests.py
@@ -57,9 +57,10 @@ def test_texttable_header():
     table.add_rows([
         ["text",    "float", "exp", "int", "bool", "auto"],
         ["abcd",    "67",    654,   89,    True,   128.001],
-        ["efghijk", 67.5434, .654,  89.6,  True,   12800000000000000000000.00023],
+        ["efghijk", 67.5434, .654,  89.6,  42,     12800000000000000000000.00023],
         ["lmn",     5e-78,   5e-78, 89.4,  False,  .000000000000128],
-        ["opqrstu", .023,    5e+78, 92.,   False,  12800000000000000000000],
+        ["opqrstu", .023,    5e+78, 92.,   0,      12800000000000000000000],
+        ["abcdef",  .023,    5e+78, 92.,   0,      False],
     ])
     assert clean(table.draw()) == dedent('''\
          text     float       exp      int   bool      auto
@@ -68,6 +69,7 @@ def test_texttable_header():
         efghijk   67.543   6.540e-01    90   True    1.280e+22
         lmn        0.000   5.000e-78    89   False   0.000
         opqrstu    0.023   5.000e+78    92   False   1.280e+22
+        abcdef     0.023   5.000e+78    92   False   False
     ''')
 
 def test_set_cols_width():

--- a/texttable.py
+++ b/texttable.py
@@ -484,7 +484,7 @@ class Texttable:
     @classmethod
     def _fmt_bool(cls, x, **kw):
         """Boolean formatting class-method"""
-        return str(x)
+        return str(bool(x))
 
     @classmethod
     def _fmt_auto(cls, x, **kw):

--- a/texttable.py
+++ b/texttable.py
@@ -311,13 +311,14 @@ class Texttable:
         """Set the desired columns datatype for the cols.
 
         - the elements of the array should be either a callable or any of
-          "a", "t", "f", "e" or "i":
+          "a", "t", "f", "e", "i" or "b":
 
             * "a": automatic (try to use the most appropriate datatype)
             * "t": treat as text
             * "f": treat as float in decimal format
             * "e": treat as float in exponential format
             * "i": treat as int
+            * "b": treat as boolean
             * a callable: should return formatted string for any value given
 
         - by default, automatic datatyping is used for each column
@@ -481,6 +482,11 @@ class Texttable:
         return obj2unicode(x)
 
     @classmethod
+    def _fmt_bool(cls, x, **kw):
+        """Boolean formatting class-method"""
+        return str(x)
+
+    @classmethod
     def _fmt_auto(cls, x, **kw):
         """auto formatting class-method."""
         f = cls._to_float(x)
@@ -489,7 +495,7 @@ class Texttable:
         elif f != f:  # NaN
             fn = cls._fmt_text
         elif f - round(f) == 0:
-            fn = cls._fmt_int
+            fn = cls._fmt_bool if isinstance(x, bool) else cls._fmt_int
         else:
             fn = cls._fmt_float
         return fn(x, **kw)
@@ -503,6 +509,7 @@ class Texttable:
         FMT = {
             'a':self._fmt_auto,
             'i':self._fmt_int,
+            'b':self._fmt_bool,
             'f':self._fmt_float,
             'e':self._fmt_exp,
             't':self._fmt_text,


### PR DESCRIPTION
Currently any table cells with boolean values are formatted as integers when using the auto-formatting option.

This patch adds a boolean formatting option `"b"` that formats value depending on their truthiness as `True` or `False` and integrates it into the auto-formatter.